### PR TITLE
Derivs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - NONUMPY=true
 
 install:
+  - pip install sphinx
   - if $NONUMPY; then pip uninstall -y numpy; fi
   - python setup.py install
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - NONUMPY=true
 
 install:
-  - pip install sphinx
+  - if [[ $TRAVIS_PYTHON_VERSION != "3.2" ]]; then pip install sphinx; fi
   - if $NONUMPY; then pip uninstall -y numpy; fi
   - python setup.py install
   - pip freeze
@@ -22,4 +22,4 @@ install:
 script:
   - nosetests -vv test_ad.py
   - cd doc
-  - make html
+  - if [[ $TRAVIS_PYTHON_VERSION != "3.2" ]]; then make html; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,23 @@
 
 language: python
 
+python:
+    - "2.6"
+    - "2.7"
+    - "3.2"
+    - "3.3"
+    - "3.4"
+
 env:
-    - NUMPY=false PY=''
-    - NUMPY=true  PY=''
-    - NUMPY=false PY=3
-    - NUMPY=true PY=3
+    - NONUMPY=false
+    - NONUMPY=true
 
 install:
-  # Deactivate the virtualenv to get fast install of dependencies
-  - deactivate
-  - sudo apt-get install -qq python$PY-sphinx python$PY-nose
-  - if $NUMPY; then sudo apt-get install -qq python$PY-numpy; fi
+  - if $NONUMPY; then pip uninstall -y numpy; fi
+  - python setup.py install
+  - pip freeze
 
 script:
-  - python$PY setup.py install --user
-
-  - python$PY test_ad.py
-
+  - nosetests -vv test_ad.py
   - cd doc
   - make html

--- a/ad/__init__.py
+++ b/ad/__init__.py
@@ -45,7 +45,7 @@ def to_auto_diff(x):
         return ADF(x, {}, {}, {})
 
     raise NotImplementedError(
-        'Automatic differentiation not yet supported for {:} objects'.format(
+        'Automatic differentiation not yet supported for {0:} objects'.format(
         type(x))
         )
         
@@ -284,9 +284,9 @@ class ADF(object):
         object, but assumes self.tag is a string object.
         """
         if self.tag is None:
-            return 'ad({:})'.format(str_func(self.x))
+            return 'ad({0:})'.format(str_func(self.x))
         else:
-            return 'ad({:}, {:})'.format(str_func(self.x), str(self.tag))
+            return 'ad({0:}, {1:})'.format(str_func(self.x), str(self.tag))
         
     def __repr__(self):
         return self._to_general_representation(repr)
@@ -1028,7 +1028,7 @@ def adnumber(x, tag=None):
             return ADV(x, tag)
 
     raise NotImplementedError(
-        'Automatic differentiation not yet supported for {:} objects'.format(
+        'Automatic differentiation not yet supported for {0:} objects'.format(
         type(x))
         )
 

--- a/ad/__init__.py
+++ b/ad/__init__.py
@@ -1173,3 +1173,51 @@ def jacobian(adfuns, advars):
             jac.append([0.0]*len(advars))
     
     return jac
+
+if numpy_installed:
+    def d(a, b, out=None):
+        """
+        Take a derivative of a with respect to b.
+        
+        This is a numpy ufunc, so the derivative will be broadcast over both a and b.
+        
+        a: scalar or array over which to take the derivative
+        b: scalar or array of variable(s) to take the derivative with respect to
+        
+        >>> x = adnumber(3)
+        >>> y = x**2
+        >>> d(y, x)
+        array(6.0, dtype=object)
+        
+        >>> import numpy as np
+        >>> from ad.admath import exp
+        >>> x = adnumber(np.linspace(0,2,5))
+        >>> y = x**2
+        >>> d(y, x)
+        array([0.0, 1.0, 2.0, 3.0, 4.0], dtype=object)
+        """
+        it = numpy.nditer([a, b, out],
+                flags = ['buffered', 'refs_ok'],
+                op_flags = [['readonly'], ['readonly'],
+                            ['writeonly', 'allocate', 'no_broadcast']])
+        for y, x, deriv in it:
+            (v1,), (v2,) = y.flat, x.flat
+            deriv[...] = v1.d(v2)
+        return it.operands[2]
+    
+    def d2(a, b, out=None):
+        """
+        Take a second derivative of a with respect to b.
+        
+        This is a numpy ufunc, so the derivative will be broadcast over both a and b.
+        
+        See d() and adnumber.d2() for more details.
+        """
+        it = numpy.nditer([a, b, out],
+                flags = ['buffered', 'refs_ok'],
+                op_flags = [['readonly'], ['readonly'],
+                            ['writeonly', 'allocate', 'no_broadcast']])
+        for y, x, deriv in it:
+            (v1,), (v2,) = y.flat, x.flat
+            deriv[...] = v1.d2(v2)
+        return it.operands[2]

--- a/ad/admath/admath.py
+++ b/ad/admath/admath.py
@@ -181,7 +181,7 @@ def _vectorize(func):
     
     vectorized_function.__name__ = n
     vectorized_function.__module__ = m
-    doc = 'Vectorized {:} function\n'.format(n)
+    doc = 'Vectorized {0:} function\n'.format(n)
     if d is not None:
         doc += d
     vectorized_function.__doc__ = doc

--- a/test_ad.py
+++ b/test_ad.py
@@ -139,15 +139,15 @@ class AdTest:
         'test coercion methods'
         x = self.x
         if isinstance(x.x, (int, float)):
-            msg = '{:} and {:}'.format(int(x), type(int(x)))
+            msg = '{0:} and {1:}'.format(int(x), type(int(x)))
             self.assertEqual(int(x), 2, msg)
             self.assertTrue(isinstance(int(x), int), msg)
              
-            msg = '{:} and {:}'.format(float(x), type(float(x)))
+            msg = '{0:} and {1:}'.format(float(x), type(float(x)))
             self.assertEqual(float(x), 2.0)
             self.assertTrue(isinstance(float(x), float))
             
-            msg = '{:} and {:}'.format(complex(x), type(complex(x)))    
+            msg = '{0:} and {1:}'.format(complex(x), type(complex(x)))    
             self.assertEqual(complex(x), 2+0j)
             self.assertTrue(isinstance(complex(x), complex))
 

--- a/test_ad.py
+++ b/test_ad.py
@@ -14,6 +14,12 @@ import math
 import cmath
 from unittest import TestCase, TestSuite
 
+try:
+    import numpy
+    numpy_installed = True
+except ImportError:
+    numpy_installed = False
+
 ################################################################################
 
     
@@ -180,6 +186,52 @@ class AdTestInt(AdTest, TestCase):
 
 class AdTestFloat(AdTest, TestCase):
     xi, yi = (2.0, 3.0)
+
+if numpy_installed:
+    import numpy as np
+    import numpy.testing
+    
+    def assert_allclose(a, b):
+        a = np.array(a, dtype=float)
+        b = np.array(b, dtype=float)
+        return numpy.testing.assert_allclose(a, b)
+    
+    class NPTests(TestCase):
+        def setUp(self):
+            self.x = adnumber(2)
+            self.x_row = adnumber(np.linspace(0, 2, 5))
+            
+            self.y = np.logspace(0,4,5)
+        
+        def test_deriv(self):
+            """Test ad.d() function"""
+            z = self.y * self.x
+            dz = ad.d(z, self.x)
+            assert_allclose(dz, self.y)
+            
+            z = self.x_row ** 2
+            dz = ad.d(z, self.x_row)
+            assert_allclose(dz, [0.0, 1.0, 2.0, 3.0, 4.0])
+            
+            z = self.y * self.x_row
+            dz = ad.d(z, self.x_row)
+            assert_allclose(dz, self.y)
+        
+        def test_d2(self):
+            """Test ad.d2() function"""
+            z = self.y * exp(-2*self.x)
+            dz = ad.d(z, self.x)
+            ddz = ad.d2(z, self.x)
+            assert_allclose(dz, -2*z)
+            assert_allclose(ddz, 4*z)
+            
+            z = self.x_row ** 2
+            ddz = ad.d2(z, self.x_row)
+            assert_allclose(ddz, 2.)
+            
+            z = self.y * sin(2*self.x_row)
+            ddz = ad.d2(z, self.x_row)
+            assert_allclose(ddz, -4*z)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_ad.py
+++ b/test_ad.py
@@ -12,141 +12,174 @@ from ad import *
 from ad.admath import *
 import math
 import cmath
+from unittest import TestCase, TestSuite
 
 ################################################################################
-for xi, yi in zip((2, 2.0), (3, 3.0)):
-    
-    # variables to test
-    x = adnumber(xi, tag='x')
-    y = adnumber(yi)
-    
-    # test tag property
-    assert x.tag=='x'
-    assert y.tag==None
-    
-    # test object comparisons
-    assert x==2
-    assert x!=1
-    assert x  # nonzero
-    assert x<3
-    assert x<=2
-    assert x>1
-    assert x>=2
-    
-    assert y==3
-    assert y!=2
-    assert y  # nonzero
-    assert y<4
-    assert y<=3
-    assert y>2
-    assert y>=3
-    
-    # test underlying object comparisons
-    assert x.x==2
-    assert y.x==3
-    
-    # test derivatives of ADV (independent variable) objects
-    assert x.d(x)==1
-    assert y.d(y)==1
-    assert y.d(x)==0
-    assert x.d(y)==0
-    assert x.d(1)==0
-    assert y.d(1)==0
-    assert x.d2(x)==0
-    assert y.d2(y)==0
-    assert x.d2(y)==0
-    assert y.d2(x)==0
-    
-    # test derivatives of ADF (dependent variable) objects
-    z_add = x + y
-    assert z_add==xi + yi, z_add
-    assert z_add.d(x)==1, z_add.d(x)
-    assert z_add.d(y)==1, z_add.d(y)
-    assert z_add.d(z_add)==0, z_add.d(z_add) # dependent variables not traced
-    assert z_add.d2(x)==0, z_add.d2(x)
-    assert z_add.d2(y)==0, z_add.d2(y)
-    assert z_add.d2c(x, y)==0, z_add.d2c(x, y)
-    assert z_add.d2c(y, x)==z_add.d2c(x, y), z_add.d2c(y, x)
-    assert z_add.d2c(x, z_add)==0, z_add.d2c(x, z_add)
-    assert z_add.gradient([x, 1, y])==[1, 0, 1], z_add.gradient([x, 1, y])
 
-    z_sub = x - y
-    assert z_sub==xi - yi, z_sub
-    assert z_sub.d(x)==1, z_sub.d(x)
-    assert z_sub.d(y)==-1, z_sub.d(y)
-    assert z_sub.d2(x)==0, z_sub.d2(x)
-    assert z_sub.d2(y)==0, z_sub.d2(y)
-    assert z_sub.d2c(x, y)==0, z_sub.d2c(x, y)
-    assert z_sub.gradient([x, y, z_add])==[1, -1, 0], z_sub.gradient([x, y, z_add])
+    
+class AdTest:
+    def setUp(self):
+        self.x = adnumber(self.xi, tag='x')
+        self.y = adnumber(self.yi)
+    
+    def test_tags(self):
+        'test tag property'
+        self.assertEqual(self.x.tag, 'x')
+        self.assertTrue(self.y.tag is None)
+    
+    def test_comparisons(self):
+        'test object comparisons'
+        x,y = self.x, self.y
+        
+        self.assertEqual(x, 2)
+        self.assertNotEqual(x, 1)
+        self.assertTrue(x)  # nonzero
+        self.assertTrue(x < 3)
+        self.assertTrue(x <= 2)
+        self.assertTrue(x > 1)
+        self.assertTrue(x >= 2)
+        
+        self.assertEqual(y, 3)
+        self.assertNotEqual(y, 2)
+        self.assertTrue(y)  # nonzero
+        self.assertTrue(y < 4)
+        self.assertTrue(y <= 3)
+        self.assertTrue(y > 2)
+        self.assertTrue(y >= 3)
+        
+        # test underlying object comparisons
+        self.assertEqual(x.x, 2)
+        self.assertEqual(y.x, 3)
+    
+    def test_ADV_derivs(self):
+        "test derivatives of ADV (independent variable) objects"
+        x,y = self.x, self.y
+        self.assertEqual(x.d(x), 1)
+        self.assertEqual(y.d(y), 1)
+        self.assertEqual(y.d(x), 0)
+        self.assertEqual(x.d(y), 0)
+        self.assertEqual(x.d(1), 0)
+        self.assertEqual(y.d(1), 0)
+        self.assertEqual(x.d2(x), 0)
+        self.assertEqual(y.d2(y), 0)
+        self.assertEqual(x.d2(y), 0)
+        self.assertEqual(y.d2(x), 0)
 
-    z_mul = x*y
-    assert z_mul==xi*yi, z_mul
-    assert z_mul.d(x)==3, z_mul.d(x)
-    assert z_mul.d(y)==2, z_mul.d(y)
-    assert z_mul.d2(x)==0, z_mul.d2(x)
-    assert z_mul.d2(y)==0, z_mul.d2(y)
-    assert z_mul.d2c(x, y)==1, z_mul.d2c(x, y)
-    
-    z_div = x/y
-    assert z_div==xi/yi, z_div
-    assert z_div.d(x)==1./yi, z_div.d(x)
-    assert z_div.d(y)==-xi/(yi**2), z_div.d(y)
-    assert z_div.d2(x)==0, z_div.d2(x)
-    assert z_div.d2(y)==2*xi/(yi**3), z_div.d2(y)
-    assert z_div.d2c(x, y)==-1./9, z_div.d2c(x, y)
-    
-    z_pow = x**y
-    assert z_pow==xi**yi, z_pow
-    assert z_pow.d(x)==12, z_pow.d(x)
-    assert z_pow.d(y)==(8*math.log(2)), z_pow.d(y)
-    assert z_pow.d2(x)==12, z_pow.d2(x)
-    assert z_pow.d2(y)==(8*math.log(2)**2), z_pow.d2(y)
-    assert z_pow.d2c(x, y)==(4 + 12*math.log(2)), z_pow.d2c(x, y)
-    assert z_pow.hessian([z_mul, y, x])==[
-        [0,                  0,                  0], 
-        [0,   8*math.log(2)**2, 4 + 12*math.log(2)], 
-        [0, 4 + 12*math.log(2),                 12]], \
-        z_pow.hessian([z_mul, y, x])
-    
-    z_mod = x%y
-    assert z_mod==(x - y*ad._floor(x/y)), z_mod
-    
-    z_neg = -x
-    assert z_neg==-1*x.x, z_neg
-    
-    z_pos = +x
-    assert z_pos==x.x, z_pos
-    
-    z_inv = ~x
-    assert z_inv==-(x+1), z_inv
-    
-    z_abs = abs(-x.x)
-    assert z_abs==x, z_abs
-    
-    # test coercion methods
-    if isinstance(x.x, (int, float)):
-        assert int(x)==2 and isinstance(int(x), int), '{:} and {:}'.format(
-            int(x), type(int(x)))
-        assert float(x)==2.0 and isinstance(float(x), float), \
-            '{:} and {:}'.format(float(x), type(float(x)))
-    assert complex(x)==2+0j and isinstance(complex(x), complex), \
-        '{:} and {:}'.format(complex(x), type(complex(x)))
-    
-    # test trace_me
-    z_add.trace_me()
-    z_add.d(z_add)==1, z_add.d(z_add)
-    z_add.d2(z_add)==0, z_add.d2(z_add)
-    
-    # test gh function wrapper
-    def test_func(x, a):
-        return (x[0] + x[1])**a
-    testg, testh = gh(test_func)
-    assert testg([x, y], 3)==((x + y)**3).gradient([x, y]), testg([x, y], 3)
-    assert testh([x, y], 3)==((x + y)**3).hessian([x, y]), testh([x, y], 3)
+    def test_ADF_derivs(self):
+        'test derivatives of ADF (dependent variable) objects'
+        x, y = self.x, self.y
+        xi, yi = self.xi, self.yi
+        z_add = x + y
+        self.assertEqual(z_add, xi + yi)
+        self.assertEqual(z_add.d(x), 1)
+        self.assertEqual(z_add.d(y), 1)
+        
+        # dependent variables not traced
+        self.assertEqual(z_add.d(z_add), 0)
+        self.assertEqual(z_add.d2(x), 0)
+        self.assertEqual(z_add.d2(y), 0)
+        self.assertEqual(z_add.d2c(x, y), 0)
+        self.assertEqual(z_add.d2c(y, x), z_add.d2c(x, y))
+        self.assertEqual(z_add.d2c(x, z_add), 0)
+        self.assertEqual(z_add.gradient([x, 1, y]), [1, 0, 1])
 
-    # test jacobian function
-    assert jacobian([z_mul, z_add], [x, 1, y])==[[3.0, 0.0, 2.0], 
-                                                 [1.0, 0.0, 1.0]], \
-        jacobian([z_mul, z_add], [x, 1, y])
+        z_sub = x - y
+        self.assertEqual(z_sub, xi - yi)
+        self.assertEqual(z_sub.d(x), 1)
+        self.assertEqual(z_sub.d(y), -1)
+        self.assertEqual(z_sub.d2(x), 0)
+        self.assertEqual(z_sub.d2(y), 0)
+        self.assertEqual(z_sub.d2c(x, y), 0)
+        self.assertEqual(z_sub.gradient([x, y, z_add]), [1, -1, 0])
+
+        z_mul = x*y
+        self.assertEqual(z_mul, xi*yi)
+        self.assertEqual(z_mul.d(x), 3)
+        self.assertEqual(z_mul.d(y), 2)
+        self.assertEqual(z_mul.d2(x), 0)
+        self.assertEqual(z_mul.d2(y), 0)
+        self.assertEqual(z_mul.d2c(x, y), 1)
+        
+        z_div = x/y
+        self.assertEqual(z_div, xi/yi)
+        self.assertEqual(z_div.d(x), 1./yi)
+        self.assertEqual(z_div.d(y), -xi/(yi**2))
+        self.assertEqual(z_div.d2(x), 0)
+        self.assertEqual(z_div.d2(y), 2*xi/(yi**3))
+        self.assertEqual(z_div.d2c(x, y), -1./9)
+        
+        z_pow = x**y
+        self.assertEqual(z_pow, xi**yi)
+        self.assertEqual(z_pow.d(x), 12)
+        self.assertEqual(z_pow.d(y), (8*math.log(2)))
+        self.assertEqual(z_pow.d2(x), 12)
+        self.assertEqual(z_pow.d2(y), (8*math.log(2)**2))
+        self.assertEqual(z_pow.d2c(x, y), (4 + 12*math.log(2)))
+        self.assertEqual(z_pow.hessian([z_mul, y, x]), [
+            [0,                  0,                  0], 
+            [0,   8*math.log(2)**2, 4 + 12*math.log(2)], 
+            [0, 4 + 12*math.log(2),                 12]])
+        
+        z_mod = x%y
+        self.assertEqual(z_mod, (x - y*ad._floor(x/y)))
+        
+        z_neg = -x
+        self.assertEqual(z_neg, -1*x.x)
+        
+        z_pos = +x
+        self.assertEqual(z_pos, x.x)
+        
+        z_inv = ~x
+        self.assertEqual(z_inv, -(x+1))
+        
+        z_abs = abs(-x.x)
+        self.assertEqual(z_abs, x)
     
-    print('** All tests passed successfully for xi={:} and yi={:}!'.format(xi, yi))
+    def test_coercion(self):
+        'test coercion methods'
+        x = self.x
+        if isinstance(x.x, (int, float)):
+            msg = '{:} and {:}'.format(int(x), type(int(x)))
+            self.assertEqual(int(x), 2, msg)
+            self.assertTrue(isinstance(int(x), int), msg)
+             
+            msg = '{:} and {:}'.format(float(x), type(float(x)))
+            self.assertEqual(float(x), 2.0)
+            self.assertTrue(isinstance(float(x), float))
+            
+            msg = '{:} and {:}'.format(complex(x), type(complex(x)))    
+            self.assertEqual(complex(x), 2+0j)
+            self.assertTrue(isinstance(complex(x), complex))
+
+
+    def test_trace(self):
+        'test trace_me'
+        z_add = self.x + self.y
+        z_add.trace_me()
+        self.assertEqual(z_add.d(z_add), 1)
+        self.assertEqual(z_add.d2(z_add), 0)
+    
+    def test_gh(self):
+        'test gh function wrapper'
+        x, y = self.x, self.y
+        def test_func(x, a):
+            return (x[0] + x[1])**a
+        testg, testh = gh(test_func)
+        self.assertEqual(testg([x, y], 3), ((x + y)**3).gradient([x, y]))
+        self.assertEqual(testh([x, y], 3), ((x + y)**3).hessian([x, y]))
+
+    def test_jacobian(self):
+        'test jacobian function'
+        x, y = self.x, self.y
+        self.assertEqual(jacobian([x*y, x+y], [x, 1, y]),
+                    [[3.0, 0.0, 2.0], [1.0, 0.0, 1.0]])
+    
+
+class AdTestInt(AdTest, TestCase):
+    xi, yi = (2, 3)
+
+class AdTestFloat(AdTest, TestCase):
+    xi, yi = (2.0, 3.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds `d()` and `d2()` convenience functions, which work with numpy to broadcast across arrays, as discussed in issue #5 (and thus should close #5).

This branch is based on my `testing` branch (PR #7), so you might want to merge that first.