### PR TITLE
log() returns incorrect derivatives for base != e

### DIFF
--- a/ad/admath/admath.py
+++ b/ad/admath/admath.py
@@ -1101,8 +1101,8 @@ def log(x, base=None):
         # Calculation of the derivatives with respect to the arguments
         # of f (ad_funcs):
 
-        lc_wrt_args = [1./x]
-        qc_wrt_args = [-1./x**2]
+        lc_wrt_args = [1./(x * ln(base))]
+        qc_wrt_args = [-1./(x**2 * ln(base))]
         cp_wrt_args = 0.0
 
         ########################################

--- a/test_ad.py
+++ b/test_ad.py
@@ -108,6 +108,11 @@ for xi, yi in zip((2, 2.0), (3, 3.0)):
         [0, 4 + 12*math.log(2),                 12]], \
         z_pow.hessian([z_mul, y, x])
     
+    for base in (2, 10, math.e):
+        z_log = log(x, base)
+        assert z_log.d(x) == 1. / (x * ln(base))
+        assert z_log.d2(x) == -1. / (x**2 * ln(base))
+
     z_mod = x%y
     assert z_mod==(x - y*ad._floor(x/y)), z_mod
     


### PR DESCRIPTION
They are off by a factor of ln(base).