### PR TITLE
Fix lint CI: migrate ruff suppressions from noqa to ruff: ignore

### DIFF
--- a/ad/__init__.py
+++ b/ad/__init__.py
@@ -782,7 +782,7 @@ class ADF(_ADFArithmetic, _ADFComparison):
     def __bool__(self) -> bool:
         return bool(self.x)
 
-    def __array_ufunc__(  # noqa: PLW3201
+    def __array_ufunc__(  # ruff: ignore[bad-dunder-method-name]
         self, ufunc: object, method: str, *inputs: object, **kwargs: object
     ) -> object:
         """Support NumPy ufunc dispatch (e.g. ``numpy.sin(x)``) on ADF objects.
@@ -797,11 +797,11 @@ class ADF(_ADFArithmetic, _ADFComparison):
         if method != "__call__":
             return NotImplemented
 
-        import operator  # noqa: PLC0415
+        import operator  # ruff: ignore[import-outside-top-level]
 
-        import numpy as np  # noqa: PLC0415
+        import numpy as np  # ruff: ignore[import-outside-top-level]
 
-        import ad.admath as adm  # noqa: PLC0415
+        import ad.admath as adm  # ruff: ignore[import-outside-top-level]
 
         math_ufunc_map = {
             np.sin: adm.sin,


### PR DESCRIPTION
## Lint

ruff 0.16 added three preview rules. These configs set `preview = true` and
use an unpinned `astral-sh/ruff-action@v3`, so CI went red with no change on
our side:

| Rule | Migration |
| --- | --- |
| `RUF105` noqa-comments | `# noqa: X` → `# ruff: ignore[X]` |
| `RUF106` rule-codes-in-suppression-comments | code → readable name |
| `RUF201` rule-codes-in-selectors | same, for `per-file-ignores` |

Suppressions now name the rule they silence, e.g.
`# noqa: PLW3201` → `# ruff: ignore[bad-dunder-method-name]`.

Fixes were scoped to exactly these three rules rather than a blanket
`--fix`: ruff's autofix mangles malformed input, turning `# noqa RUF067`
(missing colon) into `# ruff: ignore[...] RUF067` with stray trailing text.
Comments and config selectors only — no behavioural change.

## Verification

`ruff check` and `ruff format --diff` both pass using this workflow's own
command, and the test suite passes locally via uv.

Not verified: the macOS steps could not be exercised locally (no macOS
runner). Worth watching the first CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
